### PR TITLE
Make work like all other bookshelf plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ You can pass in a validation object as a class attribute when you extend
 var db        = require(knex)(require('./knexfile'));
 var bookshelf = require('bookshelf')(db);
 // Pass an initialized bookshelf instance
-var ModelBase = require('bookshelf-modelbase')(bookshelf);
+require('bookshelf-modelbase')(bookshelf);
 
-var User = ModelBase.extend({
+var User = bookshelf.Model.extend({
   tableName: 'users'
 
   // validation is passed to Joi.object(), so use a raw object

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,5 +134,5 @@ module.exports = function modelBase (bookshelf, params) {
 
   })
 
-  return model
+  bookshelf.Model = model
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ var chai = require('chai')
 var expect = chai.expect
 var db = require('./db')
 var bookshelf = require('bookshelf')(db)
-var ModelBase = require('../lib/index')(bookshelf)
+require('../lib/index')(bookshelf)
 
 describe('modelBase', function () {
   var specimen
@@ -16,7 +16,7 @@ describe('modelBase', function () {
   })
 
   beforeEach(function () {
-    SpecimenClass = ModelBase.extend({
+    SpecimenClass = bookshelf.Model.extend({
       tableName: 'test_table',
       validate: {
         first_name: Joi.string().valid('hello', 'goodbye', 'yo').required(),
@@ -39,7 +39,7 @@ describe('modelBase', function () {
     })
 
     it('should default to any validation', function () {
-      specimen = new ModelBase()
+      specimen = new bookshelf.Model()
       expect(specimen.validate.isJoi).to.eql(true)
       expect(specimen.validate._type).to.eql('any')
     })
@@ -47,7 +47,7 @@ describe('modelBase', function () {
 
   describe('validateSave', function () {
     it('should allow extended Joi object', function () {
-      SpecimenClass = ModelBase.extend({
+      SpecimenClass = bookshelf.Model.extend({
         tableName: 'test_table',
         validate: Joi.object().keys({
           first_name: Joi.string().valid('hello', 'goodbye')
@@ -97,7 +97,7 @@ describe('modelBase', function () {
 
   describe('constructor', function () {
     it('should itself be extensible', function () {
-      return expect(ModelBase.extend({ tablefirst_name: 'test' }))
+      return expect(bookshelf.Model.extend({ tablefirst_name: 'test' }))
         .to.itself.respondTo('extend')
     })
   })


### PR DESCRIPTION
All kinds of bad things can happen if you return the model instead of setting the bookshelf.model in the plugin. If you want it to play nice with all other plugins I would suggest pulling in this pull request. If you don't you will always have to be the last plugin.

JT