### PR TITLE
Throw actual Joi Error object + Don't break initialize inheritance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,11 +7,9 @@ module.exports = function modelBase (bookshelf, params) {
     throw new Error('Must pass an initialized bookshelf instance')
   }
 
-  var modelPrototype = bookshelf.Model.prototype
-
   var model = bookshelf.Model.extend({
-    initialize: function (attrs, options) {
-      modelPrototype.initialize.call(this)
+    constructor: function () {
+      bookshelf.Model.apply(this, arguments)
 
       if (this.validate) {
         var baseValidation = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ module.exports = function modelBase (bookshelf, params) {
       }
 
       if (validation.error) {
-        throw new Error(validation.error)
+        throw validation.error
       } else {
         return validation.value
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -132,5 +132,5 @@ module.exports = function modelBase (bookshelf, params) {
 
   })
 
-  bookshelf.Model = model
+  return model
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-modelbase",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Extensible ModelBase for bookshelf-based model layers",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
**UPDATE 2**

We have to actually return `modelbase` from the factory for this change to work.. If not we get a `RangeError: Maximum call stack size exceeded`, that makes sense.

So I changed the last line:

```js
bookshelf.Model = model

// To:
return model;
```

It was originally like that though (returning the `model`), why did you change this behaviour? I think it is cleaner *not* to override `bookshelf.Model`, but what was the reason to do so?

**UPDATE**

I did another small commit/fix in that master branch so I edit this pull request to include both changes.

I hope that's alright. Please advise.


## Throw actual Joi Error object

Commit: https://github.com/eightyfive/bookshelf-modelbase/commit/e82f5ed4f5ef7365f030aa3dc125e94cb6d9c6f6

I did a small fix in order to throw the actual Joi `Error` object and have access to all detailed information provided by Joi:

```js
 [ValidationError: "user_id" must be a number]
  name: 'ValidationError',
  details: 
   [ { message: '"user_id" must be a number',
       path: 'user_id',
       type: 'number.base',
       context: [Object] } ],
  _object: 
   { user_id: 'benoit',
     name: 'benoit sagols',
     ...},
  annotate: [Function] }
```

## Don't break initialize inheritance

Commit: https://github.com/eightyfive/bookshelf-modelbase/commit/a0c44a9d12c6846cd41a8a814fccf911cc575c5f

Instead of using `initialize` for `modelbase` initialization, I made use of `constructor` method as advised in [Bookshelf official documentation](http://bookshelfjs.org/#Model-subsection-construction):

> In rare cases, if you're looking to get fancy, you may want to override constructor, which allows you to replace the actual constructor function for your model.

That way:

- We can use `initialize` method normally in sub-sequent models extending `modelbase`
- We don't break Bookshelf `initialize` functionality which is [meant to remain empty](https://github.com/tgriesser/bookshelf/blob/master/src/base/model.js#L85) for the base model.
- We stick to common accepted way to extend Backbone-kind Libs. This is how [MarionetteJS extends Backbone](https://github.com/marionettejs/backbone.marionette/blob/master/src/view.js#L11) for instance.


Both changes are non-breaking.

 


