### PR TITLE
Add the table name to the error message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,8 @@ module.exports = function modelBase (bookshelf, params) {
       }
 
       if (validation.error) {
+        validation.error.tableName = this.tableName
+
         throw validation.error
       } else {
         return validation.value

--- a/test/index.js
+++ b/test/index.js
@@ -65,10 +65,16 @@ describe('modelBase', function () {
     })
 
     it('should error on invalid attributes', function () {
+      var error
+
       specimen.set('first_name', 1)
-      expect(function () {
+      try {
         specimen.validateSave()
-      }).to.throw(/first_name must be a string/)
+      } catch (err) {
+        error = err
+      }
+
+      expect(error.tableName).to.equal('test_table')
     })
 
     it('should work with updates method specified', function () {


### PR DESCRIPTION
When working with a large set of tables and schemas is hard to tell which table failed to validate because the error stack inside Bookshelf's hooks doesn't contain information about that, specially if the failed field is too generic and exists in a lot of tables. This PR improves that by adding `model.tableName` to the error message and a `error.tableName` property to programmatically get the table name.

A negative point tough is that some `bookshelf-modelbase` users may be exposing this error message and showing the table's name may not be a good idea.

Another option would be creating a `Model.ValidationError` programmatically by patching `Model.extended` and throwing it instead of throwing Joi directly, so you could compare `if (error instanceOf MyModel.ValidationError)` and decide what to show.

If you accept this PR I suggest a major version bump so it wont affect who's exposing the error message.