### PR TITLE
added findOrCreateById() and findOrCreateByProperty() methods, built and ran tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ findAll: function (options) {
 }
 ```
 
-### model.findById
+#### model.findById
 
 ```javascript
 /**
@@ -154,7 +154,41 @@ findOrCreate: function (data, options) {
   })
 }
 ```
+#### model.findOrCreateById
+```js
+findOrCreateById: function (data, options, id) {
+  return this.findOne({ [this.prototype.idAttribute]: id }, extend(options, { require: false }))
+  .bind(this)
+  .then(function (model) {
+    var defaults = options && options.defaults
+    return model ?
+      model :
+      this.create(extend(defaults, data), options)
+  })
+}
+```
+#### model.findOrCreateByProperty
+```js
 
+/**
+  * Select a model based on data with contents of query and insert if not found
+  * @param {Object} data
+  * @param {Object} [options] Options for model.fetch and model.save
+  * @param {Object} [options.defaults] Defaults to apply to a create
+  * @param {Object} [query]
+  * @return {Promise(bookshelf.Model)} single Model
+  */
+findOrCreateByProperty: function (data, options, query) {
+  return this.findOne(query, extend(options, { require: false }))
+  .bind(this)
+  .then(function (model) {
+    var defaults = options && options.defaults
+    return model ?
+      model :
+      this.create(extend(defaults, data), options)
+  })
+}
+```
 #### model.update
 
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,6 +149,44 @@ module.exports = function modelBase (bookshelf, params) {
     },
 
     /**
+      * Select a model based on data with ID and insert if not found
+      * @param {Object} data
+      * @param {Object} [options] Options for model.fetch and model.save
+      * @param {Object} [options.defaults] Defaults to apply to a create
+      * @param {String} id The model's ID
+      * @return {Promise(bookshelf.Model)} single Model
+      */
+    findOrCreateById: function (data, options, id) {
+      return this.findOne({ [this.prototype.idAttribute]: id }, extend(options, { require: false }))
+      .bind(this)
+      .then(function (model) {
+        var defaults = options && options.defaults
+        return model ?
+          model :
+          this.create(extend(defaults, data), options)
+      })
+    },
+
+    /**
+      * Select a model based on data with contents of query and insert if not found
+      * @param {Object} data
+      * @param {Object} [options] Options for model.fetch and model.save
+      * @param {Object} [options.defaults] Defaults to apply to a create
+      * @param {Object} [query]
+      * @return {Promise(bookshelf.Model)} single Model
+      */
+    findOrCreateByProperty: function (data, options, query) {
+      return this.findOne(query, extend(options, { require: false }))
+      .bind(this)
+      .then(function (model) {
+        var defaults = options && options.defaults
+        return model ?
+          model :
+          this.create(extend(defaults, data), options)
+      })
+    },
+
+    /**
      * Select a model based on data and update if found, insert if not found
      * @param {Object} selectData Data for select
      * @param {Object} updateData Data for update

--- a/test/index.js
+++ b/test/index.js
@@ -424,7 +424,6 @@ describe('modelBase', function () {
       })
     })
   })
-  // end alex test
 
   describe('upsert', function () {
     it('should update if existing model found', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -287,6 +287,145 @@ describe('modelBase', function () {
     })
   })
 
+  describe('findOrCreateByProperty', function () {
+    it('should find an existing model', function () {
+      return SpecimenClass.findOrCreateByProperty({ id: specimen.id }, null, { id: specimen.id })
+      .then(function (model) {
+        expect(model.id).to.eql(specimen.id)
+        expect(model.get('first_name')).to.equal('hello')
+      })
+    })
+
+    it('should find with options', function () {
+      return SpecimenClass.findOrCreateByProperty({ id: specimen.id }, { columns: 'id' }, { id: specimen.id })
+      .then(function (model) {
+        expect(model.id).to.eql(specimen.id)
+        expect(model.get('first_name')).to.equal(undefined)
+      })
+    })
+
+    it('should not apply defaults when model found', function () {
+      return SpecimenClass.findOrCreateByProperty({ id: specimen.id }, { defaults: { last_name: 'world' } }, { id: specimen.id })
+      .then(function (model) {
+        expect(model.id).to.eql(specimen.id)
+        expect(model.get('first_name')).to.equal('hello')
+        expect(model.get('last_name')).to.be.null()
+      })
+    })
+
+    it('should create when model not found', function () {
+      return SpecimenClass.findOrCreateByProperty({
+        first_name: 'hello',
+        last_name: '' + new Date()
+      })
+      .then(function (model) {
+        expect(model.id).to.not.eql(specimen.id)
+      })
+    })
+
+    it('should apply defaults if creating', function () {
+      var date = '' + new Date()
+
+      return SpecimenClass.findOrCreateByProperty({
+        last_name: date
+      }, {
+        defaults: { first_name: 'hello'
+      }
+      }, {
+        last_name: date }
+      )
+      .then(function (model) {
+        expect(model.id).to.not.eql(specimen.id)
+        expect(model.get('first_name')).to.equal('hello')
+        expect(model.get('last_name')).to.equal(date)
+      })
+    })
+
+    it('should work with defaults and options', function () {
+      return SpecimenClass.findOrCreateByProperty({
+        id: specimen.id
+      }, {
+        defaults: { last_name: 'hello' },
+        columns: ['id', 'last_name']
+      }, {
+        id: specimen.id
+      })
+      .then(function (model) {
+        expect(model.get('id')).to.equal(specimen.id)
+        expect(model.get('first_name')).to.be.undefined()
+        expect(model.get('last_name')).to.be.null()
+      })
+    })
+  })
+
+  describe('findOrCreateById', function () {
+    it('should find an existing model', function () {
+      return SpecimenClass.findOrCreateById({ id: specimen.id }, null, specimen.id)
+      .then(function (model) {
+        expect(model.id).to.eql(specimen.id)
+        expect(model.get('first_name')).to.equal('hello')
+      })
+    })
+
+    it('should find with options', function () {
+      return SpecimenClass.findOrCreateById({ id: specimen.id }, { columns: 'id' }, specimen.id)
+      .then(function (model) {
+        expect(model.id).to.eql(specimen.id)
+        expect(model.get('first_name')).to.equal(undefined)
+      })
+    })
+
+    it('should not apply defaults when model found', function () {
+      return SpecimenClass.findOrCreateById({ id: specimen.id }, { defaults: { last_name: 'world' } }, specimen.id)
+      .then(function (model) {
+        expect(model.id).to.eql(specimen.id)
+        expect(model.get('first_name')).to.equal('hello')
+        expect(model.get('last_name')).to.be.null()
+      })
+    })
+
+    it('should create when model not found', function () {
+      return SpecimenClass.findOrCreateById({
+        first_name: 'hello',
+        last_name: '' + new Date()
+      })
+      .then(function (model) {
+        expect(model.id).to.not.eql(specimen.id)
+      })
+    })
+
+    it('should apply defaults if creating', function () {
+      var date = '' + new Date()
+
+      return SpecimenClass.findOrCreateById({
+        last_name: date
+      }, {
+        defaults: { first_name: 'hello'
+      }
+      })
+      .then(function (model) {
+        expect(model.id).to.not.eql(specimen.id)
+        expect(model.get('first_name')).to.equal('hello')
+        expect(model.get('last_name')).to.equal(date)
+      })
+    })
+
+    it('should work with defaults and options', function () {
+      return SpecimenClass.findOrCreateById({
+        id: specimen.id
+      }, {
+        defaults: { last_name: 'hello' },
+        columns: ['id', 'last_name']
+      }, specimen.id)
+      .then(function (model) {
+        expect(model.get('id')).to.equal(specimen.id)
+        expect(model.get('first_name')).to.be.undefined()
+        expect(model.get('last_name')).to.be.null()
+      })
+    })
+  })
+  // end alex test
+
   describe('upsert', function () {
     it('should update if existing model found', function () {
       return SpecimenClass.create({


### PR DESCRIPTION
the method findOrCreate() is great. I need  to find or create in the database based off of a single property as apposed to the entire object. Ideally we will have a findOrCreateById() implemented in the same fashion as findById(), and a custom findOrCreateByProperty() which can accept a query object. 

Additionally, new tests should be created for both new methods. Tests must pass.

As an example, we will check for a single property, ```username```, and find or create a record based on this data point. From there, return the data from the promise object returned as a means of demonstration.

```js
// bring in user table
var User = ModelBase.extend({
    tableName: 'users'
});

// find or create query with custom property object.
User.findOrCreateByProperty( {
  username: 'yourUserNameHere',
  age: 25,
  company: 'yourCompanyHere',
  email: 'yourEmailHere',
  location: 'yourLocationHere',
  name: 'yourNameHere'
}, null, { username: 'yourUserNameHere' }).then((collection) => {
  if(collection){
    return collection.attributes;
  }
});
```

PR inbound!!
--thexande