### PR TITLE
[Feature] Adds key omission options to toJSON

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ module.exports = function modelBase (bookshelf, params) {
       if (!(options && options.omit)) { return json }
       if (!(Array.isArray(options.omit) && typeof options.omit !== 'object')) { return json }
 
-      return omitDeep(json, options.omit);
+      return omitDeep(json, options.omit)
     }
 
   }, {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var extend = require('xtend')
 var Joi = require('joi')
 var difference = require('lodash.difference')
+var omitDeep = require('omit-deep-lodash')
 
 module.exports = function modelBase (bookshelf, params) {
   if (!bookshelf) {
@@ -53,6 +54,14 @@ module.exports = function modelBase (bookshelf, params) {
       } else {
         return validation.value
       }
+    },
+
+    serialize: function (options) {
+      const json = bookshelfModel.prototype.serialize.call(this, options)
+      if (!(options && options.omit)) { return json }
+      if (!(Array.isArray(options.omit) && typeof options.omit !== 'object')) { return json }
+
+      return omitDeep(json, options.omit);
     }
 
   }, {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "joi": "^9.0.4",
     "lodash.difference": "^4.4.0",
+    "omit-deep-lodash": "^0.8.0",
     "xtend": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Note: Built on PR #43.
Also Note: Does not include tests.  I would love the help writing the tests!

This feature adds an `omit` option.  Omission is done recursively. Here is an example use:

```javascript
const omitKeys = ['password','id','deleted_at','created_at','updated_at']
const json = myModel.toJSON({ omit: omitKeys })
```

or

```javascript
const json = myModel.toJSON({ omit: 'password' })
```

or

```javascript
const omitKeys = { 'password': 'DoNotUsePlainText' }
const json = myModel.toJSON({ omit: omitKeys })
```
