### PR TITLE
preserve `this.validate` on merge `baseValidation`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ module.exports = function modelBase (bookshelf, params) {
 
         this.validate = this.validate.isJoi
            ? this.validate.keys(baseValidation)
-           : Joi.object(this.validate).keys(baseValidation)
+           : Joi.object(baseValidation).keys(this.validate)
 
         this.on('saving', this.validateSave)
       }


### PR DESCRIPTION
This PR is based on the issue #52.

When we're using the `validate`, we're unable to redefine the behavior of properties in the baseValidation. This PR will allow we to override this properties. 